### PR TITLE
resolves #2, globstars and alike

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,8 @@
 
 'use stric';
 
-var reBlock = '\\/\\*';
-var reBlockIgnore = '\\/\\*(?!\\*?\\!)';
-var reBlockEnd = '(.|[\\r\\n]|\\n)*?\\*\\/\\n?\\n?';
+var reBlock = /\/\*(?!\/)(.|[\r\n]|\n)+?\*\/\n?\n?/gm
+var reBlockIgnore = /\/\*(?!(\*?\/|\*?\!))(.|[\r\n]|\n)+?\*\/\n?\n?/gm
 var reLine = /(^|[^\S\n])(?:\/\/)([\s\S]+?)$/gm;
 var reLineIgnore = /(^|[^\S\n])(?:\/\/[^!])([\s\S]+?)$/gm;
 
@@ -44,9 +43,9 @@ var strip = module.exports = function(str, opts) {
 
 strip.block = function(str, opts) {
   opts = opts || {};
-  var re = new RegExp(reBlock + reBlockEnd, 'gm');
+  var re = reBlock //new RegExp(reBlock + reBlockEnd, 'gm');
   if(opts.safe) {
-    re = new RegExp(reBlockIgnore + reBlockEnd, 'gm');
+    re = reBlockIgnore //new RegExp(reBlockIgnore + reBlockEnd, 'gm');
   }
   return str ? str.replace(re, '') : '';
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "mocha -R spec"
+    "test": "mocha --require should"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/expected/strip-all.js
+++ b/test/expected/strip-all.js
@@ -18,3 +18,7 @@ var baz = function() {
 
 
 var fun = false;
+
+var path = '/path/to/*/something/that/not/be/stripped.js';
+
+var globstar = '/path/to/globstar/not/be/stripped/**/*.js';

--- a/test/expected/strip-keep-block.js
+++ b/test/expected/strip-keep-block.js
@@ -26,3 +26,7 @@ var baz = function() {
 // also this multiline
 // line comment
 var fun = false;
+
+var path = '/path/to/*/something/that/not/be/stripped.js';
+
+var globstar = '/path/to/globstar/not/be/stripped/**/*.js';

--- a/test/expected/strip-keep-line.js
+++ b/test/expected/strip-keep-line.js
@@ -26,3 +26,6 @@ var baz = function() {
   
   var but = 'not'; //! that comment
 };
+
+var path = '/path/to/*/something/that/not/be/stripped.js';
+var globstar = '/path/to/globstar/not/be/stripped/**/*.js';

--- a/test/fixtures/strip-all.js
+++ b/test/fixtures/strip-all.js
@@ -31,3 +31,5 @@ var baz = function() {
 // also this multiline
 // line comment
 var fun = false;
+var path = '/path/to/*/something/that/not/be/stripped.js';
+var globstar = '/path/to/globstar/not/be/stripped/**/*.js';

--- a/test/fixtures/strip-keep-line.js
+++ b/test/fixtures/strip-keep-line.js
@@ -26,3 +26,6 @@ var baz = function() {
   // var removed = 'yes';
   var but = 'not'; //! that comment
 };
+
+var path = '/path/to/*/something/that/not/be/stripped.js';
+var globstar = '/path/to/globstar/not/be/stripped/**/*.js';

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,0 @@
---reporter spec
---require should

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,36 @@ describe('strip:', function () {
     var expected = 'foo // this is a comment\n';
     normalize(actual).should.eql(normalize(expected));
   });
+
+  it('should strip all but not `/*/`', function() {
+    var actual = strip("/* I will be stripped */\nvar path = '/and/this/*/not/be/stripped';")
+    var expected = "\nvar path = '/and/this/*/not/be/stripped';"
+    normalize(actual).should.eql(normalize(expected));
+  })
+
+  it('should strip all but not globstars `/**/*` #1', function() {
+    var actual = strip("var path = './path/to/scripts/**/*.js';")
+    var expected = "var path = './path/to/scripts/**/*.js';"
+    normalize(actual).should.eql(normalize(expected));
+  })
+
+  it('should strip all but not globstars `/**/` #2 and `//!` line comments (safe:true)', function() {
+    var actual = strip("var partPath = './path/*/to/scripts/**/'; //! line comment", {safe:true})
+    var expected = "var partPath = './path/*/to/scripts/**/'; //! line comment"
+    normalize(actual).should.eql(normalize(expected));
+  })
+
+  it('should strip all but not `/*/*something` from anywhere', function() {
+    var actual = strip("var partPath = './path/*/*something/test.txt';")
+    var expected = "var partPath = './path/*/*something/test.txt';"
+    normalize(actual).should.eql(normalize(expected));
+  })
+
+  it('should strip all but not `/*/*something/*.js` from anywhere (globstar-like)', function() {
+    var actual = strip("var partPath = './path/*/*something/*.js';")
+    var expected = "var partPath = './path/*/*something/*.js';"
+    normalize(actual).should.eql(normalize(expected));
+  })
 });
 
 describe('strip all or empty:', function () {


### PR DESCRIPTION
@jonschlinkert @jonathanong
Guys, cheers! LOL
- Resolves https://github.com/jonschlinkert/strip-comments/issues/2 , globstars and alike.
- added more tests

But something like this one will continue failing. Or at all, is this possible as usecase?

``` js
  it('should strip all but not multiple globstars `./path/to/**/*mega/globstar/**/*.txt`', function() {
    var actual = strip("var src = './path/to/**/*mega/globstar/**/*.txt';")
    var expected = "var src = './path/to/**/*mega/globstar/**/*.txt';"
    normalize(actual).should.eql(normalize(expected));
  })
```
