### PR TITLE
tests: string and regexp literals

### DIFF
--- a/test/fixtures/no-comment.js
+++ b/test/fixtures/no-comment.js
@@ -1,0 +1,12 @@
+'use strict';
+
+process.stdout.write('string literals: ');
+console.dir({
+  str0: '&apos;',
+  str1: "&quot;",
+});
+
+process.stdout.write('RegExp literals: ');
+console.dir({
+  regexp0: /I'm the easiest in Chomsky hierarchy!/,
+});

--- a/test/test.js
+++ b/test/test.js
@@ -59,6 +59,13 @@ describe('strip:', function () {
     var expected = "var partPath = './path/*/*something/*.js';"
     normalize(actual).should.eql(normalize(expected));
   })
+
+  it('should leave alone code without any comments', function() {
+    var fixture = read('test/fixtures/no-comment.js');
+    var actual = strip(fixture);
+    var expected = fixture;
+    actual.should.eql(expected);
+  })
 });
 
 describe('strip all or empty:', function () {


### PR DESCRIPTION
Let's test some string and regexp literals that are not comments. Thus they shouldn't be stripped, and they aren't, so this test passes.
