### PR TITLE
tests: not a comment: snake-y ASCII art

### DIFF
--- a/test/fixtures/no-comment.js
+++ b/test/fixtures/no-comment.js
@@ -4,6 +4,7 @@ process.stdout.write('string literals: ');
 console.dir({
   str0: '&apos;',
   str1: "&quot;",
+  str2: ". // ' \\ . // ' \\ .",
 });
 
 process.stdout.write('RegExp literals: ');


### PR DESCRIPTION
The test that led to #12. `strip-comments` removes parts of a string literal. It's output might even be of invalid syntax, can't easily see that in current test output format.
