### PR TITLE
Handle comments that are substrings of a later comment

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function discard(str, comment, opts) {
   if (opts && opts.safe === true && ch === '!') {
     return str;
   }
-  return str.split(comment.raw).join('');
+  return str.replace(comment.raw, '');
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -89,6 +89,23 @@ describe('strip:', function() {
     var expected = fixture;
     assert.equal(actual, expected);
   });
+
+  it('should not break on comments that are substrings of a later comment', function() {
+    // see https://github.com/jonschlinkert/strip-comments/issues/27
+    var actual = strip([
+      '// this is a substring',
+      '// this is a substring of a larger comment',
+      'someCode();',
+      'someMoreCode();'
+    ].join('\n'));
+    var expected = [
+      '',
+      '',
+      'someCode();',
+      'someMoreCode();'
+    ].join('\n');
+    assert.equal(actual, expected);
+  });
 });
 
 describe('error handling:', function() {


### PR DESCRIPTION
Resolves https://github.com/jonschlinkert/strip-comments/issues/27