### PR TITLE
fix: typo 'typscript' -> 'typescript'

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Works with:
 * shebang
 * sql
 * swift
-* typscript
+* typescript
 * xml
 
 ## Usage

--- a/lib/languages.js
+++ b/lib/languages.js
@@ -81,5 +81,5 @@ exports.sass = exports.javascript;
 exports.sql = exports.ada;
 exports.swift = exports.javascript;
 exports.ts = exports.javascript;
-exports.typscript = exports.javascript;
+exports.typescript = exports.javascript;
 exports.xml = exports.html;

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "sql comments",
     "strip",
     "swift comments",
-    "typscript comments",
+    "typescript comments",
     "xml comments"
   ],
   "verb": {


### PR DESCRIPTION
Hello!
Just a minor change.

(_I think this description doesn't require to be longer._)